### PR TITLE
fix: Tag was always empty

### DIFF
--- a/main.js
+++ b/main.js
@@ -34,12 +34,13 @@ var getRepo = {
   }
 }
 request.get(getRepo, function(err, response, body){
-    
-  if(response['body'] == null){
+
+  var tag_name = ""
+  if(response['body'] != null){
     tag_name = response['body']['tag_name'];
   }
-  var tag_name = "",
-      embed = 
+
+  var embed =
         {
           "title": `${title} ${tag_name}`,
           "description": `${description}`,


### PR DESCRIPTION
I've been using this webhook but it always fails to give me an empty tag. Judging by [this commit](https://github.com/LeGitHubDeTai/github-to-discord/commit/e14a91d8ad5cc0aff00a636cb224023de7568305), I think you know it. I think the problem is that you're inverting the if clause and only attempting to read the tag if the JSON body is empty.